### PR TITLE
fix: do not percent-decode the font name

### DIFF
--- a/app/src/components/ChatDisplay.svelte
+++ b/app/src/components/ChatDisplay.svelte
@@ -106,7 +106,7 @@
                         ? `${font.includes(" ") ? `"${font}"` : font}, Geist`
                         : "Geist";
 
-                    customFont = decodeURIComponent(font);
+                    customFont = font;
 
                     break;
                 case "fontSize":


### PR DESCRIPTION
## Proposed changes

ChatOverlay reads settings with `URLSearchParams`, which already percent decodes, so the font name arrives at ChatDisplay fully decoded. `decodeURIComponent` then ran a second decode on it, which throws a `URIError` on any name containing a bare `%` and aborts the whole settings pass, so every setting after `font` stops applying geeg.

## Link to the API Pull request (if API change required):

N/A

## Notes

N/A

## Checklist

Put an `x` in the boxes that apply. You can also fill them out later after creating the PR.
</br>Do not remove any of the checkboxes.

- [x] I agree to the guidelines outlined in [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] The code is readable and follows the existing style.
- [ ] Any new UI text has been added to the locale files
- [ ] Any new non-first-party API endpoints do not send user data (telemetry, analytics, etc.).
- [ ] This change could be breaking.
- [ ] This PR depends on an API or backend change.
  - [ ] I have tested it against a local build using [this repo](https://github.com/Fiszh/uniiDev) and opened a corresponding PR there.
- [ ] This PR adds my bot to the custom bot list.
  - [ ] My bot is not recognized as a bot by [Twitch](https://help.twitch.tv/s/article/chat-bot-badge-about) or [FFZ](https://api.frankerfacez.com/v1/badges).
  - [ ] The bot is publicly accessible (not private or test-only).
- [ ] This PR adds a new setting.
- [ ] This PR adds or changes CSS.
  - [ ] Mobile only.
  - [ ] PC only.
  - [ ] Both.
- [ ] This PR relates to only one platform.
  - [ ] Twitch.
  - [ ] Kick.
